### PR TITLE
fix: downgrade yarn version used on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@
   command = "npm run build"
   functions = "lambda"
 [build.environment]
-  YARN_VERSION = "1.9.4"
+  YARN_VERSION = "1.4.0"
   YARN_FLAGS = "--no-ignore-optional"


### PR DESCRIPTION
Netlify stoppet alle builds fordi dere ikke har oppdatert hvilket image som benyttes til å bygge nye publiseringer. Tilhørende issues med løsning er beskrevet under:

- https://answers.netlify.com/t/error-gatsby-plugin-manifest-input-file-contains-unsupported-image-format/71145
- https://github.com/gatsbyjs/gatsby/issues/3570
- https://github.com/gatsbyjs/gatsby/issues/28204